### PR TITLE
Added preliminary check to clearErrors method

### DIFF
--- a/src/datums/datum.cjsx
+++ b/src/datums/datum.cjsx
@@ -824,7 +824,9 @@ module.exports = class Datum extends React.Component
     This method can be used to clear any validation or save errors manually
   ###
   clearErrors: ->
-    @setState errors: []
+    # Only set the state if there were errors to begin with.
+    if _.isArray(@state.errors) and @state.errors.length > 0
+      @setState errors: []
     
     
   


### PR DESCRIPTION
This is much more performant, especially on large grids where there are no errors but framework code might still be calling this method.